### PR TITLE
feat: Implemented print_stack function to track call stack depth for debugging

### DIFF
--- a/test/test_beta_reduction.py
+++ b/test/test_beta_reduction.py
@@ -5,7 +5,7 @@ from token_type import TokenType
 from lexer import Lexer
 from parser import Parser
 from ast_internal import Expression, VariableNode, LambdaAbstractionNode, LambdaApplicationNode
-from beta_reduction_v2 import Evaluator
+from beta_reduction import Evaluator
 
 class TestBetaReduction(unittest.TestCase):
 

--- a/test/test_print_stack.py
+++ b/test/test_print_stack.py
@@ -1,0 +1,57 @@
+import unittest
+import io
+import sys
+from unittest.mock import patch
+from stack import print_stack
+
+
+class TestPrintStack(unittest.TestCase):
+
+    def setUp(self):
+        self.stdout = io.StringIO()
+        self.stdout = self.stdout
+    
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+    
+    def test_debug_off(self):
+        @print_stack
+        def sample_func(x):
+            return x * 2
+
+        result = sample_func(5)
+        self.assertEqual(result, 10)
+        self.assertEqual(self.stdout.getvalue(), '')
+
+    @patch.dict('os.environ', {'DEBUG': '1'})
+    def test_debug_on(self):
+        @print_stack
+        def sample_func(x):
+            return x * 2
+        
+        result = sample_func(5)
+        output = self.stdout.getvalue()
+        self.assertEqual(result, 10)
+        self.assertIn(output, 'Entering sample_func')
+        self.assertIn(output, 'args (5,)')
+        self.assertIn(output, 'Exiting sample_func')
+
+    @unittest.skip
+    @patch.dict('os.environ', {'DEBUG': '1'})
+    def test_max_depth_exceeded(self):
+        @print_stack
+        def recursive_func(n):
+            if n <= 0: return 0
+            return recursive_func(n - 1)
+
+        with self.assertRaises(Exception) as context:
+            recursive_func(501)
+        self.assertIn(str(context.exception), 'Maximum call stack depth exceeded')
+    
+    def test_invalid_decorator_input(self):
+        with self.assertRaises(TypeError):
+            print_stack("not a function")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Overview
- Wrote a function named `print_stack` to track call stack depth for debugging
- This function sits under an env variable named `DEBUG`.
- run `DEBUG=1 python3 -m unittest test/test_beta_reduction.py` to see the full stack trace
- Removed `Stack` and `StackFrame` classes since its no longer needed.